### PR TITLE
Some major problems getting postgres backups working.. fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ pgsql-archlog
 pgsql-restore
 Makefile
 .libs
+
+# Editor Backup Files
+*~

--- a/pgsql-fd.c
+++ b/pgsql-fd.c
@@ -452,8 +452,14 @@ bRC parse_plugin_command ( bpContext *ctx, const ParseMode parse_mode, const cha
          FREE ( pinst->configfile );
          return bRC_Error;
       }
-   
-      pinst->paramlist = parse_config_file ( pinst->configfile );
+
+      if((pinst->paramlist = parse_config_file ( pinst->configfile )) == NULL) {
+          char errbuf[255];
+          JMSG2(ctx, M_FATAL, "Error reading config file: %s (%s)", pinst->configfile, 
+              strerror_r(errno, errbuf, sizeof(errbuf)));
+          FREE( pinst->configfile );
+          return bRC_Error;
+      }
       pinst->restore_command_value = bstrdup ( command );
    }
    return bRC_OK;

--- a/pgsqllib.c
+++ b/pgsqllib.c
@@ -46,22 +46,18 @@ void pgsqllibinit ( int argc, char * argv[] ){
 
    char * prg;
    char * nprg;
-   char * dirtmp;
    
    prg = bstrdup ( argv[0] );
    nprg = basename ( prg );
    program_name = bstrdup ( nprg );
    FREE ( prg );
    
-   dirtmp = MALLOC ( PATH_MAX );
-   if ( realpath ( argv[0], dirtmp ) == NULL ){
+   program_directory = MALLOC ( PATH_MAX );
+   if ( realpath ( argv[0], program_directory ) == NULL ){
       /* error in resolving path */
-      FREE ( dirtmp );
-      dirtmp = argv[0];
+      FREE ( program_directory );
+      program_directory = argv[0];
    }
-   program_directory = bstrdup ( dirtmp );
-   
-   FREE ( dirtmp );
 }
 
 /* returns a pointer into program name variable */


### PR DESCRIPTION
Trying to get pgsql-fd working in our setup, I had some major issues that turned out to be bugs, as follows:

1) The code allows for the possibility that realpath() may return NULL under some circumstances and tries to handle this.  But the malloc/free logic was bad, causing a crash.  Also, needless duplicate allocation was being done.  This has been fixed and cleaned up.

2) The code was not checking to see if the config file had been successfully opened after getting a backup or restore event.  This resulted in a false Success job status with zero length backup in the case of failure to read the file.  I have put in a check and returned an M_FATAL JobMessage to prevent this occurrence.  Note that this filename is embedded in the FileSet so it's pretty easy for this error to occur. 

Thanks!
